### PR TITLE
Revert "Add phone directory to frameworks/base."

### DIFF
--- a/core/pathmap.mk
+++ b/core/pathmap.mk
@@ -116,7 +116,6 @@ FRAMEWORKS_BASE_SUBDIRS := \
 	    sax \
 	    telecomm \
 	    telephony \
-	    phone \
 	    wifi \
 	    keystore \
 	    rs \


### PR DESCRIPTION
There is no phone directory in frameworks/base.
Remove this to reduce build warnings.

This reverts commit 7d36e1574fc196c314c1f590284dfe8783211a48.

Change-Id: Ia495461189e75b23deb2f4bdc393ec7de993527a